### PR TITLE
Laravel 6 integration and azure Url support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Configure your disk in `config/filesystem.php`
                 'name' => env('AZURE_ACCOUNT_NAME'),
                 'key' => env('AZURE_ACCOUNT_KEY'),
             ],
+            'url' => env('AZURE_STORAGE_URL', null),
             'endpoint-suffix' => env('AZURE_ENDPOINT_SUFFIX', 'core.windows.net'),
             'container' => env('AZURE_CONTAINER', 'public')
         ]

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/support": "~5.7|~5.8",
+        "illuminate/support": "~5.7|~5.8|^6.0",
         "league/flysystem-azure-blob-storage": "^0.1.5"
     },
     "require-dev": {

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace DiamondByBOLD\FlysystemAzureBlobStorage;
+
+use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter as BaseAzureBlobStorageAdapter;
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
+
+final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
+{
+    /**
+     * The Azure Blob Client
+     *
+     * @var BlobRestProxy
+     */
+    private $client;
+
+    /**
+     * The container name
+     *
+     * @var string
+     */
+    private $container;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * AzureBlobStorageAdapter constructor.
+     * @param BlobRestProxy $client
+     * @param string $container
+     * @param string|null $url
+     * @param null $prefix
+     * @throws \Exception
+     */
+    public function __construct(BlobRestProxy $client, string $container, string $url = null, $prefix = null)
+    {
+        parent::__construct($client, $container, $prefix);
+
+        $this->client = $client;
+        $this->container = $container;
+        $this->setPathPrefix($prefix);
+
+        if ($url && !filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new \Exception('Invalid Url');
+        }
+        $this->url = $url;
+    }
+
+    public function getUrl(string $path) : string{
+        if ($this->url) {
+            return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ltrim($path, '/');
+        }
+
+        return $this->client->getBlobUrl($this->container, $path);
+    }
+}

--- a/src/FlysystemAzureBlobStorageServiceProvider.php
+++ b/src/FlysystemAzureBlobStorageServiceProvider.php
@@ -6,7 +6,6 @@ use League\Flysystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
-use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
 
 class FlysystemAzureBlobStorageServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
- Update dependencies to work on Laravel 6
- When using azure storage without the media library you can now use flysystems url method which previously wasn't implemented