### PR TITLE
prefix support while object creation of AzureBlobStorageAdapter

### DIFF
--- a/src/FlysystemAzureBlobStorageServiceProvider.php
+++ b/src/FlysystemAzureBlobStorageServiceProvider.php
@@ -26,7 +26,7 @@ class FlysystemAzureBlobStorageServiceProvider extends ServiceProvider
 
             $client = BlobRestProxy::createBlobService($connectionString);
 
-            return new Filesystem(new AzureBlobStorageAdapter($client, $config['container']));
+            return new Filesystem(new AzureBlobStorageAdapter($client, $config['container'], ($config['prefix'] ?? null)));
         });
     }
 


### PR DESCRIPTION
Added prefix param while object creation of AzureBlobStorageAdapter, if prefix is exist in filesystem config.

Some project have custom folder stricture in storage.
- projectstroage
	- local_resource
		- media_id
			- file
		- media_id
			- file
	- staging_resource 
		- media_id
			- file
		- media_id
			- file
	- production_resource 
		- media_id
			- file
		- media_id
			- file

So when at time of object creation can able to pass environment based resource folder as prefix.